### PR TITLE
Remove attrs runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ With this release, DDRR only supports Python 3.11-3.14 and Django 5.2-6.0.
 
 ### Removed
 
+- Runtime dependency on attrs
 - Support for Python < 3.11
 - Support for Django < 5.2
 

--- a/ddrr/records.py
+++ b/ddrr/records.py
@@ -1,7 +1,7 @@
 import textwrap
+from dataclasses import dataclass
 from typing import Any
 
-import attr
 from django.http import RawPostDataException
 from django.utils.functional import cached_property
 
@@ -9,11 +9,16 @@ from ddrr.utils import collect_request_headers
 from ddrr.utils import pretty_print
 
 
-@attr.define(slots=False)
+@dataclass(init=False)
 class RequestLogRecord:
     record: Any
     request: Any
-    _formatter: Any = attr.field(alias="formatter")
+    _formatter: Any
+
+    def __init__(self, record: Any, request: Any, formatter: Any) -> None:
+        self.record = record
+        self.request = request
+        self._formatter = formatter
 
     @cached_property
     def headers(self):
@@ -68,11 +73,16 @@ class RequestLogRecord:
         return cls(record=record, request=record.msg, formatter=formatter)
 
 
-@attr.define(slots=False)
+@dataclass(init=False)
 class ResponseLogRecord:
     record: Any
     response: Any
-    _formatter: Any = attr.field(alias="formatter")
+    _formatter: Any
+
+    def __init__(self, record: Any, response: Any, formatter: Any) -> None:
+        self.record = record
+        self.response = response
+        self._formatter = formatter
 
     @cached_property
     def headers(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 ]
 dependencies = [
     "Django>=5.2,<6.1",
-    "attrs>=22.2,<22.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,44 @@
+from ddrr.records import RequestLogRecord
+from ddrr.records import ResponseLogRecord
+
+
+def test_request_log_record_accepts_formatter_alias():
+    record = object()
+    request = object()
+    formatter = object()
+
+    log_record = RequestLogRecord(
+        record=record,
+        request=request,
+        formatter=formatter,
+    )
+
+    assert log_record.record is record
+    assert log_record.request is request
+    assert log_record._formatter is formatter
+    assert vars(log_record) == {
+        "record": record,
+        "request": request,
+        "_formatter": formatter,
+    }
+
+
+def test_response_log_record_accepts_formatter_alias():
+    record = object()
+    response = object()
+    formatter = object()
+
+    log_record = ResponseLogRecord(
+        record=record,
+        response=response,
+        formatter=formatter,
+    )
+
+    assert log_record.record is record
+    assert log_record.response is response
+    assert log_record._formatter is formatter
+    assert vars(log_record) == {
+        "record": record,
+        "response": response,
+        "_formatter": formatter,
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -23,15 +23,6 @@ wheels = [
 ]
 
 [[package]]
-name = "attrs"
-version = "22.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/31/3f468da74c7de4fcf9b25591e682856389b3400b4b62f201e65f15ea3e07/attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99", size = 215900, upload-time = "2022-12-21T09:48:51.773Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836", size = 60018, upload-time = "2022-12-21T09:48:49.401Z" },
-]
-
-[[package]]
 name = "cachetools"
 version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -63,7 +54,6 @@ name = "ddrr"
 version = "3.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "attrs" },
     { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or extra == 'group-4-ddrr-django52'" },
     { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra != 'group-4-ddrr-django52') or (extra == 'group-4-ddrr-django52' and extra == 'group-4-ddrr-django60')" },
 ]
@@ -94,7 +84,6 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "attrs", specifier = ">=22.2,<22.3" },
     { name = "django", specifier = ">=5.2,<6.1" },
     { name = "lxml", marker = "extra == 'xml'", specifier = ">=5.4,<7" },
 ]


### PR DESCRIPTION
Replaces the limited attrs usage in the request and response record wrappers with standard-library dataclasses while preserving the formatter constructor alias and instance dictionaries required by cached properties. Removes attrs from project metadata and uv.lock, and adds focused constructor regression tests. Validation: full Python 3.11-3.14 / Django 5.2-6.0 tox matrix, Ruff, formatting, ty, and all pre-commit hooks.